### PR TITLE
Bump Dalamud.LoadingImage to API8 and NET 7.0

### DIFF
--- a/Dalamud.LoadingImage/Dalamud.LoadingImage.csproj
+++ b/Dalamud.LoadingImage/Dalamud.LoadingImage.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Target">
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyVersion>1.0.0.9</AssemblyVersion>
+    <AssemblyVersion>1.0.0.10</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
@@ -40,7 +40,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.8" />
+    <PackageReference Include="DalamudPackager" Version="2.1.10" />
     <Reference Include="Dalamud" Private="False" />
     <Reference Include="ImGui.NET" Private="False" />
     <Reference Include="ImGuiScene" Private="False" />

--- a/Dalamud.LoadingImage/LoadingImagePlugin.cs
+++ b/Dalamud.LoadingImage/LoadingImagePlugin.cs
@@ -59,11 +59,11 @@ namespace Dalamud.LoadingImage
             this.loadings = dataManager.GetExcelSheet<LoadingImage>().ToArray();
             this.cfcs = dataManager.GetExcelSheet<ContentFinderCondition>().ToArray();
 
-            this.printIconHook = new Hook<PrintIconPathDelegate>(
+            this.printIconHook = Hook<PrintIconPathDelegate>.FromAddress(
                 sigScanner.ScanText("40 53 48 83 EC 40 41 83 F8 01"),
                 this.PrintIconPathDetour);
 
-            this.handleTerriChangeHook = new Hook<HandleTerriChangeDelegate>(
+            this.handleTerriChangeHook = Hook<HandleTerriChangeDelegate>.FromAddress(
                 sigScanner.ScanText("40 53 55 56 41 56 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 4C 8B F1 41 0F B6 F1"),
                 this.HandleTerriChangeDetour);
 

--- a/Dalamud.LoadingImage/packages.lock.json
+++ b/Dalamud.LoadingImage/packages.lock.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
   "dependencies": {
-    "net5.0-windows7.0": {
+    "net7.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.8, )",
-        "resolved": "2.1.8",
-        "contentHash": "YqagNXs9InxmqkXzq7kLveImxnodkBEicAhydMXVp7dFjC7xb76U6zGgAax4/BWIWfZeWzr5DJyQSev31kj81A=="
+        "requested": "[2.1.10, )",
+        "resolved": "2.1.10",
+        "contentHash": "S6NrvvOnLgT4GDdgwuKVJjbFo+8ZEj+JsEYk9ojjOR/MMfv1dIFpT8aRJQfI24rtDcw1uF+GnSSMN4WW1yt7fw=="
       },
       "Newtonsoft.Json": {
         "type": "Direct",


### PR DESCRIPTION
AssemblyVersion was also bumped to 1.0.0.10

Signatures are still valid for 6.3 so are unchanged.