### PR TITLE
1.0.0.13 - API11 and 7.0 Fixes

### DIFF
--- a/Dalamud.LoadingImage/Dalamud.LoadingImage.csproj
+++ b/Dalamud.LoadingImage/Dalamud.LoadingImage.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup Label="Target">
     <TargetFramework>net8.0-windows</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -40,7 +40,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.13" />
+    <PackageReference Include="DalamudPackager" Version="11.0.0" />
     <Reference Include="Dalamud" Private="False" />
     <Reference Include="ImGui.NET" Private="False" />
     <Reference Include="ImGuiScene" Private="False" />

--- a/Dalamud.LoadingImage/Dalamud.LoadingImage.csproj
+++ b/Dalamud.LoadingImage/Dalamud.LoadingImage.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Target">
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyVersion>1.0.0.12</AssemblyVersion>
+    <AssemblyVersion>1.0.0.13</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -40,7 +40,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.12" />
+    <PackageReference Include="DalamudPackager" Version="2.1.13" />
     <Reference Include="Dalamud" Private="False" />
     <Reference Include="ImGui.NET" Private="False" />
     <Reference Include="ImGuiScene" Private="False" />

--- a/Dalamud.LoadingImage/LoadingImage.cs
+++ b/Dalamud.LoadingImage/LoadingImage.cs
@@ -1,27 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Lumina;
-using Lumina.Data;
-using Lumina.Excel;
-using Lumina.Excel.GeneratedSheets;
-using Lumina.Text;
+﻿using Lumina.Excel;
+using Lumina.Text.ReadOnly;
 
 namespace Dalamud.LoadingImage
 {
    [Sheet( "LoadingImage" )]
-    public class LoadingImage : ExcelRow
+   public readonly struct LoadingImage(ExcelPage page, uint offset, uint row) : IExcelRow<LoadingImage>
     {
-        
-        public SeString Name { get; set; }
+        public uint RowId => row;
 
-        public override void PopulateData( RowParser parser, GameData gameData, Language language )
-        {
-            base.PopulateData( parser, gameData, language );
+        public ReadOnlySeString Name => page.ReadString( offset, offset );
 
-            Name = parser.ReadColumn< SeString >( 0 );
-        }
+        public static LoadingImage Create(ExcelPage page, uint offset, uint row) => new(page, offset, row);
     }
 }

--- a/Dalamud.LoadingImage/packages.lock.json
+++ b/Dalamud.LoadingImage/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.13, )",
-        "resolved": "2.1.13",
-        "contentHash": "rMN1omGe8536f4xLMvx9NwfvpAc9YFFfeXJ1t4P4PE6Gu8WCIoFliR1sh07hM+bfODmesk/dvMbji7vNI+B/pQ=="
+        "requested": "[11.0.0, )",
+        "resolved": "11.0.0",
+        "contentHash": "bjT7XUlhIJSmsE/O76b7weUX+evvGQctbQB8aKXt94o+oPWxHpCepxAGMs7Thow3AzCyqWs7cOpp9/2wcgRRQA=="
       },
       "Newtonsoft.Json": {
         "type": "Direct",

--- a/Dalamud.LoadingImage/packages.lock.json
+++ b/Dalamud.LoadingImage/packages.lock.json
@@ -1,18 +1,18 @@
 {
   "version": 1,
   "dependencies": {
-    "net7.0-windows7.0": {
+    "net8.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.12, )",
-        "resolved": "2.1.12",
-        "contentHash": "Sc0PVxvgg4NQjcI8n10/VfUQBAS4O+Fw2pZrAqBdRMbthYGeogzu5+xmIGCGmsEZ/ukMOBuAqiNiB5qA3MRalg=="
+        "requested": "[2.1.13, )",
+        "resolved": "2.1.13",
+        "contentHash": "rMN1omGe8536f4xLMvx9NwfvpAc9YFFfeXJ1t4P4PE6Gu8WCIoFliR1sh07hM+bfODmesk/dvMbji7vNI+B/pQ=="
       },
       "Newtonsoft.Json": {
         "type": "Direct",
-        "requested": "[13.0.1, )",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+        "requested": "[13.0.3, )",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",


### PR DESCRIPTION
This PR adds support for 7.0, important notes:

1. PrintIconPathDelegate was inlined to a bigger function that is responsible for Icon loading with 7.0, that detour was replaced by an Addon Listener that replaces the addon image when the _LocationTitle addon is being drawn, from my testing, this behaves identically to the previous hook.
2. I have not moved the logic on FrameworkOnOnUpdateEvent to that listener, since i wanted to be conservative with changes, but i could do that if it's desirable. 

![image](https://github.com/user-attachments/assets/2b36231b-e9bf-4ba6-9877-d6d6b739f4ab)
(Don't mind the weird colors, it's an HDR screenshot tonemapped to SDR, which is why it looks weird)
